### PR TITLE
Repair some of the blink results before the next statistical analysis

### DIFF
--- a/Calc_Blink.m
+++ b/Calc_Blink.m
@@ -1,6 +1,8 @@
 function Calc_Blink(taskname)
 addpath scripts
-blink_res = calc_blink(taskname);
-save(fullfile('EOG', sprintf('blink_res_%s', taskname)), 'blink_res', '-v7.3', '-nocompression')
+data_path = 'EOG';
+load(fullfile(data_path, sprintf('EOG_%s.mat', taskname))); %#ok<LOAD>
+blink_res = calc_blink(EOG);
+save(fullfile(data_path, sprintf('blink_res_%s', taskname)), 'blink_res', '-v7.3', '-nocompression')
 rmpath scripts
 end

--- a/Repair_Blink.m
+++ b/Repair_Blink.m
@@ -1,0 +1,28 @@
+function Repair_Blink(taskname)
+%REPAIR_BLINK Recovers subjects with inverted upper and lower electrodes
+%   Make sure Check_Blink is done before run this.
+%
+%See also Check_Blink
+addpath scripts
+log_path = 'logs';
+data_path = 'EOG';
+check_results = readtable(fullfile(log_path, sprintf('check_results_%s.txt', taskname)));
+if ismember('Recheck', check_results.Properties.VariableNames)
+    rows_to_repair = check_results.Recheck == -1;
+else
+    rows_to_repair = check_results.Message == -1;
+end
+load(fullfile(data_path, sprintf('EOG_%s.mat', taskname))) %#ok<LOAD>
+EOG = EOG(rows_to_repair); %#ok<NODEF>
+for i_repair = 1:length(EOG)
+    EOGv_to_repair = EOG(i_repair).EOGv;
+    for i_trial = 1:length(EOGv_to_repair.trial)
+        EOGv_to_repair.trial{i_trial}(1:2, :) = EOGv_to_repair.trial{i_trial}(2:-1:1, :);
+        EOGv_to_repair.trial{i_trial}(3, :) = -EOGv_to_repair.trial{i_trial}(3, :);
+    end
+    EOG(i_repair).EOGv = EOGv_to_repair;
+end
+blink_res = calc_blink(EOG);
+save(fullfile(data_path, sprintf('EOG_%s_repaired', taskname)), 'EOG', '-v7.3', '-nocompression')
+save(fullfile(data_path, sprintf('blink_res_%s_repaired', taskname)), 'blink_res', '-v7.3', '-nocompression')
+rmpath scripts

--- a/scripts/calc_blink.m
+++ b/scripts/calc_blink.m
@@ -2,7 +2,7 @@
 function blink_res = calc_blink(EOG)
 % This script is used to determine eye blink pattern in EOG dataset
 % Please run Extract_EOG before using this.
-h_log_err = fopen(fullfile('logs', 'readerror.log'), 'a');
+h_log_err = fopen(fullfile('logs', 'errlog.log'), 'a');
 nsubj      = length(EOG);
 % preallocate
 pid        = nan(nsubj, 1); %Participant ID
@@ -12,13 +12,14 @@ rate_blink = nan(nsubj, 1); %Number of blinks of each minute.
 stat       = cell(nsubj, 1);
 for isub = 1:nsubj
     pid(isub) = EOG(isub).pid;
-    fprintf('Now processing subject %d (id: %d).\n', isub, pid(isub));
+    fprintf('Now detecting blinks subject %d (id: %d).\n', isub, pid(isub));
     if isempty(EOG(isub).EOGv)
         continue
     end
     ntrial = length(EOG(isub).EOGv.trial);
     if ntrial == 0
-        fprintf(h_log_err, 'No trial data found for subject %d (id: %d).\n', isub, pid(isub));
+        fprintf(h_log_err, '[%s] No trial data found for subject %d (id: %d).\n', ...
+            datestr(now), isub, pid(isub));
     else
         nblink(isub)   = 0;
         task_dur(isub) = 0;
@@ -34,13 +35,11 @@ for isub = 1:nsubj
                         stat{isub}(itrial) = blinkstat;
                     end
                 catch exception
-                    fprintf(h_log_err, 'Fatal error occured when calculating blinks for %dth subject %d.\n\tErrorMessage: %s\n', ...
-                        isub, pid(isub), exception.message);
-                    fclose(h_log_err);
-                    rethrow(exception);
+                    fprintf(h_log_err, '[%s] Fatal error occured when detecting blinks for subject %d.\n\tErrorMessage: %s\n', ...
+                        datestr(now), pid(isub), exception.message);
                 end
             else
-                fprintf(h_log_err, 'No data in the %dth trial for %dth subject %d,\n', itrial, isub, pid(isub));
+                fprintf(h_log_err, '[%s] No data in the %dth trial for subject %d,\n', datestr(now), itrial, pid(isub));
             end
         end
         rate_blink(isub) = nblink(isub) / (task_dur(isub) / 60);

--- a/scripts/calc_blink.m
+++ b/scripts/calc_blink.m
@@ -1,10 +1,8 @@
 % All rights are reserved. (c) 2019 Liang Zhang (psychelzh@outlook.com)
-function blink_res = calc_blink(taskname)
+function blink_res = calc_blink(EOG)
 % This script is used to determine eye blink pattern in EOG dataset
 % Please run Extract_EOG before using this.
-data_path = 'EOG';
 h_log_err = fopen(fullfile('logs', 'readerror.log'), 'a');
-load(fullfile(data_path, sprintf('EOG_%s.mat', taskname))); %#ok<LOAD>
 nsubj      = length(EOG);
 % preallocate
 pid        = nan(nsubj, 1); %Participant ID


### PR DESCRIPTION
Some subjects' EOG are recorded with an inverted upper and lower EOG electrodes. So before we do further analysis, their blinking results should be repaired.

What's more, some subjects' EOG electrodes are full of noise, without any meaningful signal in it. Therefore, these results should be abondoned.